### PR TITLE
feat(brew): track bats -> bats-core

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -31,7 +31,12 @@ p6df::modules::shell::external::brew() {
   brew install parallel
 
   brew install shellcheck
-  brew install bats
+
+  brew tap kaos/shell
+  brew install bats-core
+  brew install bats-file
+  brew install bats-assert
+  brew install bats-detik
 
   brew install jq
   brew install yq


### PR DESCRIPTION
What's the plan and why?
Tuesday, September 19, 2017: This was forked from Bats at commit 0360811. It was created via git clone --bare and git push --mirror.

This bats-core repo is the community-maintained Bats project.

Why was this fork created?
There was an initial call for maintainers for the original Bats repository, but write access to it could not be obtained. With development activity stalled, this fork allowed ongoing maintenance and forward progress for Bats.
